### PR TITLE
[DirectionProvider] support undefined direction

### DIFF
--- a/src/DirectionProvider.jsx
+++ b/src/DirectionProvider.jsx
@@ -12,11 +12,12 @@ import { DIRECTIONS, CHANNEL } from './constants';
 
 const propTypes = forbidExtraProps({
   children: PropTypes.node.isRequired,
-  direction: directionPropType.isRequired,
+  direction: directionPropType,
   inline: PropTypes.bool,
 });
 
 const defaultProps = {
+  direction: undefined,
   inline: false,
 };
 
@@ -33,6 +34,9 @@ export default class DirectionProvider extends React.Component {
   }
 
   getChildContext() {
+    if (!this.props.direction) {
+      return {};
+    }
     return {
       [CHANNEL]: this.broadcast,
     };

--- a/src/DirectionProvider.jsx
+++ b/src/DirectionProvider.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { forbidExtraProps } from 'airbnb-prop-types';
+import { explicitNull, forbidExtraProps, or } from 'airbnb-prop-types';
 import brcast from 'brcast';
 import brcastShape from './proptypes/brcast';
 import directionPropType from './proptypes/direction';
@@ -12,12 +12,11 @@ import { DIRECTIONS, CHANNEL } from './constants';
 
 const propTypes = forbidExtraProps({
   children: PropTypes.node.isRequired,
-  direction: directionPropType,
+  direction: or([directionPropType, explicitNull()]).isRequired,
   inline: PropTypes.bool,
 });
 
 const defaultProps = {
-  direction: undefined,
   inline: false,
 };
 
@@ -52,7 +51,7 @@ export default class DirectionProvider extends React.Component {
     const { children, direction, inline } = this.props;
     const Tag = inline ? 'span' : 'div';
     return (
-      <Tag dir={direction}>
+      <Tag dir={direction || undefined}>
         {React.Children.only(children)}
       </Tag>
     );

--- a/src/DirectionProvider.jsx
+++ b/src/DirectionProvider.jsx
@@ -8,7 +8,7 @@ import { explicitNull, forbidExtraProps, or } from 'airbnb-prop-types';
 import brcast from 'brcast';
 import brcastShape from './proptypes/brcast';
 import directionPropType from './proptypes/direction';
-import { DIRECTIONS, CHANNEL } from './constants';
+import { DIRECTIONS, CHANNEL, defaultDirection } from './constants';
 
 const propTypes = forbidExtraProps({
   children: PropTypes.node.isRequired,
@@ -29,8 +29,6 @@ const contextTypes = {
 };
 
 export { DIRECTIONS };
-
-const defaultDirection = DIRECTIONS.LTR;
 
 function getNextDirection(props, state) {
   if (props.direction) {

--- a/src/DirectionProvider.jsx
+++ b/src/DirectionProvider.jsx
@@ -89,7 +89,7 @@ export default class DirectionProvider extends React.Component {
     const { children, direction, inline } = this.props;
     const Tag = inline ? 'span' : 'div';
     return (
-      <Tag dir={direction || undefined}>
+      <Tag dir={direction}>
         {React.Children.only(children)}
       </Tag>
     );

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,3 +4,5 @@ export const DIRECTIONS = {
   LTR: 'ltr',
   RTL: 'rtl',
 };
+
+export const defaultDirection = DIRECTIONS.LTR;

--- a/src/withDirection.jsx
+++ b/src/withDirection.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import deepmerge from 'deepmerge';
 import getComponentName from 'airbnb-prop-types/build/helpers/getComponentName';
-import { CHANNEL, DIRECTIONS } from './constants';
+import { CHANNEL, DIRECTIONS, defaultDirection } from './constants';
 import brcastShape from './proptypes/brcast';
 import directionPropType from './proptypes/direction';
 
@@ -16,10 +16,6 @@ const contextTypes = {
 };
 
 export { DIRECTIONS };
-
-// set a default direction so that a component wrapped with this HOC can be
-// used even without a DirectionProvider ancestor in its react tree.
-const defaultDirection = DIRECTIONS.LTR;
 
 // export for convenience, in order for components to spread these onto their propTypes
 export const withDirectionPropTypes = {
@@ -31,6 +27,8 @@ export default function withDirection(WrappedComponent) {
     constructor(props, context) {
       super(props, context);
       this.state = {
+        // set a default direction so that a component wrapped with this HOC can be
+        // used even without a DirectionProvider ancestor in its react tree.
         direction: context[CHANNEL] ? context[CHANNEL].getState() : defaultDirection,
       };
     }

--- a/tests/DirectionProvider_test.jsx
+++ b/tests/DirectionProvider_test.jsx
@@ -4,35 +4,37 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon-sandbox';
 
 import DirectionProvider from '../src/DirectionProvider';
-import { DIRECTIONS } from '../src/constants';
+import { DIRECTIONS, CHANNEL } from '../src/constants';
+import mockBrcast from './mocks/brcast_mock';
+
+function getWrapper(props, context) {
+  return shallow(
+    (
+      <DirectionProvider {...props}>
+        <div>Foo</div>
+      </DirectionProvider>
+    ), {
+      context,
+    },
+  );
+}
 
 describe('<DirectionProvider>', () => {
-  let children;
-  beforeEach(() => {
-    children = <div>Foo</div>;
-  });
-
   it('renders its children', () => {
-    const wrapper = shallow(
-      <DirectionProvider direction={DIRECTIONS.RTL}>{children}</DirectionProvider>,
-    );
-    expect(wrapper.contains(children)).to.eq(true);
+    const wrapper = getWrapper({ direction: DIRECTIONS.RTL });
+    expect(wrapper.contains(<div>Foo</div>)).to.eq(true);
   });
 
   it('renders a wrapping div with a dir attribute', () => {
     const direction = DIRECTIONS.RTL;
-    const wrapper = shallow(
-      <DirectionProvider direction={direction}>{children}</DirectionProvider>,
-    );
+    const wrapper = getWrapper({ direction });
     expect(wrapper).to.have.type('div');
     expect(wrapper).to.have.prop('dir', direction);
   });
 
   it('renders a wrapping span when the inline prop is true', () => {
     const direction = DIRECTIONS.RTL;
-    const wrapper = shallow(
-      <DirectionProvider direction={direction} inline>{children}</DirectionProvider>,
-    );
+    const wrapper = getWrapper({ direction, inline: true });
     expect(wrapper).to.have.type('span');
     expect(wrapper).to.have.prop('dir', direction);
   });
@@ -40,10 +42,8 @@ describe('<DirectionProvider>', () => {
   it('broadcasts the direction when the direction prop changes', () => {
     const direction = DIRECTIONS.LTR;
     const nextDirection = DIRECTIONS.RTL;
-    const wrapper = shallow(
-      <DirectionProvider direction={direction}>{children}</DirectionProvider>,
-    );
-    const broadcast = wrapper.instance().broadcast;
+    const wrapper = getWrapper({ direction });
+    const { broadcast } = wrapper.instance();
     const broadcastSpy = sinon.spy(broadcast, 'setState');
     wrapper.setProps({ direction: nextDirection });
     expect(broadcastSpy).to.have.callCount(1);
@@ -52,36 +52,172 @@ describe('<DirectionProvider>', () => {
   it('does not broadcast the direction when the direction prop stays the same', () => {
     const direction = DIRECTIONS.LTR;
     const nextDirection = DIRECTIONS.LTR;
-    const wrapper = shallow(
-      <DirectionProvider direction={direction}>{children}</DirectionProvider>,
-    );
-    const broadcast = wrapper.instance().broadcast;
+    const wrapper = getWrapper({ direction });
+    const { broadcast } = wrapper.instance();
     const broadcastSpy = sinon.spy(broadcast, 'setState');
     wrapper.setProps({ direction: nextDirection });
     expect(broadcastSpy).to.have.callCount(0);
   });
 
   describe('when direction is null', () => {
-    it('renders its children', () => {
-      const wrapper = shallow(
-        <DirectionProvider direction={null}>{children}</DirectionProvider>,
-      );
-      expect(wrapper.contains(children)).to.eq(true);
-    });
-
     it('renders a wrapping div without a dir attribute', () => {
-      const wrapper = shallow(
-        <DirectionProvider direction={null}>{children}</DirectionProvider>,
-      );
+      const wrapper = getWrapper({ direction: null });
       expect(wrapper).to.have.type('div');
       expect(wrapper).not.to.have.prop('dir');
     });
 
-    it('does not have childContext', () => {
-      const wrapper = shallow(
-        <DirectionProvider direction={null}>{children}</DirectionProvider>,
-      );
-      expect(wrapper.instance().getChildContext()).to.eql({});
+    it('renders a wrapping span without a dir attribute', () => {
+      const wrapper = getWrapper({ direction: null, inline: true });
+      expect(wrapper).to.have.type('span');
+      expect(wrapper).not.to.have.prop('dir');
+    });
+  });
+
+  it.skip('throws an error with no direction', () => {
+    expect(() => {
+      getWrapper();
+    }).to.throw();
+  });
+
+  describe('inherited direction', () => {
+    let brcast;
+    beforeEach(() => {
+      const unsubscribe = sinon.stub();
+      brcast = mockBrcast({
+        data: DIRECTIONS.LTR,
+        subscribe: sinon.stub().yields(DIRECTIONS.RTL).returns(unsubscribe),
+        unsubscribe,
+      });
+    });
+
+    describe('with a brcast context', () => {
+      let context;
+      beforeEach(() => {
+        context = {
+          [CHANNEL]: brcast,
+        };
+      });
+
+      it('sets initial state for inheritedDirection', () => {
+        const wrapper = getWrapper({ direction: null }, context);
+        expect(wrapper).to.have.state('inheritedDirection', DIRECTIONS.LTR);
+      });
+
+      it('calls brcast subscribe when the component mounts', () => {
+        const wrapper = getWrapper({ direction: null }, context);
+
+        expect(brcast.subscribe).to.have.callCount(0);
+        wrapper.instance().componentDidMount();
+        expect(brcast.subscribe).to.have.callCount(1);
+      });
+
+      it('calls brcast unsubscribe when the component unmounts', () => {
+        const wrapper = getWrapper({ direction: null }, context);
+        wrapper.instance().componentDidMount();
+
+        expect(brcast.unsubscribe).to.have.callCount(0);
+        wrapper.instance().componentWillUnmount();
+        expect(brcast.unsubscribe).to.have.callCount(1);
+      });
+
+      it('initializes broadcast with inheritedDirection when direction is null', () => {
+        const wrapper = getWrapper({ direction: null }, context);
+        const { broadcast } = wrapper.instance();
+        expect(broadcast.getState()).to.equal(DIRECTIONS.LTR);
+      });
+
+      it('initializes broadcast with given direction when set', () => {
+        const wrapper = getWrapper({ direction: DIRECTIONS.RTL }, context);
+        const { broadcast } = wrapper.instance();
+        expect(broadcast.getState()).to.equal(DIRECTIONS.RTL);
+      });
+
+      describe('when props change', () => {
+        it('broadcasts inherited direction when changing to null', () => {
+          const wrapper = getWrapper({ direction: DIRECTIONS.RTL }, context);
+          const { broadcast } = wrapper.instance();
+          const broadcastSpy = sinon.spy(broadcast, 'setState');
+
+          wrapper.setProps({ direction: null });
+
+          expect(broadcastSpy).to.have.callCount(1);
+          expect(broadcastSpy).to.have.been.calledWithExactly(DIRECTIONS.LTR);
+        });
+
+        it('broadcasts direction prop when changing from null', () => {
+          const wrapper = getWrapper({ direction: null }, context);
+          const { broadcast } = wrapper.instance();
+          const broadcastSpy = sinon.spy(broadcast, 'setState');
+
+          wrapper.setProps({ direction: DIRECTIONS.RTL });
+
+          expect(broadcastSpy).to.have.callCount(1);
+          expect(broadcastSpy).to.have.been.calledWithExactly(DIRECTIONS.RTL);
+        });
+      });
+
+      describe('when the context changes', () => {
+        it('sets state with a new direction', () => {
+          const wrapper = getWrapper({ direction: null }, context);
+          expect(wrapper).to.have.state('inheritedDirection', DIRECTIONS.LTR);
+
+          wrapper.instance().componentDidMount();
+          wrapper.update();
+          expect(wrapper).to.have.state('inheritedDirection', DIRECTIONS.RTL);
+        });
+
+        it('updates broadcast when prop.direction is null', () => {
+          const wrapper = getWrapper({ direction: null }, context);
+          const { broadcast } = wrapper.instance();
+          const broadcastSpy = sinon.spy(broadcast, 'setState');
+
+          wrapper.instance().componentDidMount();
+          wrapper.update();
+
+          expect(broadcastSpy).to.have.callCount(1);
+          expect(broadcastSpy).to.have.been.calledWithExactly(DIRECTIONS.RTL);
+        });
+
+        it('does not update broadcast when prop.direction is set', () => {
+          const wrapper = getWrapper({ direction: DIRECTIONS.LTR }, context);
+          const { broadcast } = wrapper.instance();
+          const broadcastSpy = sinon.spy(broadcast, 'setState');
+
+          wrapper.instance().componentDidMount();
+          wrapper.update();
+
+          expect(broadcastSpy).to.have.callCount(0);
+        });
+      });
+    });
+
+    describe('without a brcast context', () => {
+      let context;
+      beforeEach(() => {
+        context = {
+          [CHANNEL]: null,
+        };
+      });
+
+      it('sets initial state for inheritedDirection to the default direction', () => {
+        const wrapper = getWrapper({ direction: null }, context);
+        expect(wrapper).to.have.state('inheritedDirection', DIRECTIONS.LTR);
+      });
+
+      it('does not call brcast subscribe when the component mounts', () => {
+        const wrapper = getWrapper({ direction: null }, context);
+
+        wrapper.instance().componentDidMount();
+        expect(brcast.subscribe).to.have.callCount(0);
+      });
+
+      it('does not call brcast unsubscribe when the component unmounts', () => {
+        const wrapper = getWrapper({ direction: null }, context);
+        wrapper.instance().componentDidMount();
+
+        wrapper.instance().componentWillUnmount();
+        expect(brcast.unsubscribe).to.have.callCount(0);
+      });
     });
   });
 });

--- a/tests/DirectionProvider_test.jsx
+++ b/tests/DirectionProvider_test.jsx
@@ -61,18 +61,17 @@ describe('<DirectionProvider>', () => {
     expect(broadcastSpy).to.have.callCount(0);
   });
 
-  describe('when direction is undefined', () => {
+  describe('when direction is null', () => {
     it('renders its children', () => {
       const wrapper = shallow(
-        <DirectionProvider>{children}</DirectionProvider>,
+        <DirectionProvider direction={null}>{children}</DirectionProvider>,
       );
       expect(wrapper.contains(children)).to.eq(true);
     });
 
     it('renders a wrapping div without a dir attribute', () => {
-      const direction = DIRECTIONS.RTL;
       const wrapper = shallow(
-        <DirectionProvider>{children}</DirectionProvider>,
+        <DirectionProvider direction={null}>{children}</DirectionProvider>,
       );
       expect(wrapper).to.have.type('div');
       expect(wrapper).not.to.have.prop('dir');
@@ -80,7 +79,7 @@ describe('<DirectionProvider>', () => {
 
     it('does not have childContext', () => {
       const wrapper = shallow(
-        <DirectionProvider>{children}</DirectionProvider>,
+        <DirectionProvider direction={null}>{children}</DirectionProvider>,
       );
       expect(wrapper.instance().getChildContext()).to.eql({});
     });

--- a/tests/DirectionProvider_test.jsx
+++ b/tests/DirectionProvider_test.jsx
@@ -60,16 +60,16 @@ describe('<DirectionProvider>', () => {
   });
 
   describe('when direction is null', () => {
-    it('renders a wrapping div without a dir attribute', () => {
+    it('renders a wrapping div with a null dir attribute', () => {
       const wrapper = getWrapper({ direction: null });
       expect(wrapper).to.have.type('div');
-      expect(wrapper).not.to.have.prop('dir');
+      expect(wrapper).to.have.prop('dir', null);
     });
 
-    it('renders a wrapping span without a dir attribute', () => {
+    it('renders a wrapping span with a null dir attribute', () => {
       const wrapper = getWrapper({ direction: null, inline: true });
       expect(wrapper).to.have.type('span');
-      expect(wrapper).not.to.have.prop('dir');
+      expect(wrapper).to.have.prop('dir', null);
     });
   });
 

--- a/tests/DirectionProvider_test.jsx
+++ b/tests/DirectionProvider_test.jsx
@@ -59,7 +59,25 @@ describe('<DirectionProvider>', () => {
     expect(broadcastSpy).to.have.callCount(0);
   });
 
-  describe('when direction is null', () => {
+  describe('when direction is omitted', () => {
+    it('throws an error', () => {
+      expect(() => {
+        getWrapper();
+      }).to.throw();
+    });
+  });
+
+  describe('when direction is null (inherited)', () => {
+    let brcast;
+    beforeEach(() => {
+      const unsubscribe = sinon.stub();
+      brcast = mockBrcast({
+        data: DIRECTIONS.LTR,
+        subscribe: sinon.stub().yields(DIRECTIONS.RTL).returns(unsubscribe),
+        unsubscribe,
+      });
+    });
+
     it('renders a wrapping div with a null dir attribute', () => {
       const wrapper = getWrapper({ direction: null });
       expect(wrapper).to.have.type('div');
@@ -70,24 +88,6 @@ describe('<DirectionProvider>', () => {
       const wrapper = getWrapper({ direction: null, inline: true });
       expect(wrapper).to.have.type('span');
       expect(wrapper).to.have.prop('dir', null);
-    });
-  });
-
-  it.skip('throws an error with no direction', () => {
-    expect(() => {
-      getWrapper();
-    }).to.throw();
-  });
-
-  describe('inherited direction', () => {
-    let brcast;
-    beforeEach(() => {
-      const unsubscribe = sinon.stub();
-      brcast = mockBrcast({
-        data: DIRECTIONS.LTR,
-        subscribe: sinon.stub().yields(DIRECTIONS.RTL).returns(unsubscribe),
-        unsubscribe,
-      });
     });
 
     describe('with a brcast context', () => {

--- a/tests/DirectionProvider_test.jsx
+++ b/tests/DirectionProvider_test.jsx
@@ -60,4 +60,29 @@ describe('<DirectionProvider>', () => {
     wrapper.setProps({ direction: nextDirection });
     expect(broadcastSpy).to.have.callCount(0);
   });
+
+  describe('when direction is undefined', () => {
+    it('renders its children', () => {
+      const wrapper = shallow(
+        <DirectionProvider>{children}</DirectionProvider>,
+      );
+      expect(wrapper.contains(children)).to.eq(true);
+    });
+
+    it('renders a wrapping div without a dir attribute', () => {
+      const direction = DIRECTIONS.RTL;
+      const wrapper = shallow(
+        <DirectionProvider>{children}</DirectionProvider>,
+      );
+      expect(wrapper).to.have.type('div');
+      expect(wrapper).not.to.have.prop('dir');
+    });
+
+    it('does not have childContext', () => {
+      const wrapper = shallow(
+        <DirectionProvider>{children}</DirectionProvider>,
+      );
+      expect(wrapper.instance().getChildContext()).to.eql({});
+    });
+  });
 });

--- a/tests/DirectionProvider_test.jsx
+++ b/tests/DirectionProvider_test.jsx
@@ -3,8 +3,8 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon-sandbox';
 
+import { CHANNEL, DIRECTIONS, defaultDirection } from '../src/constants';
 import DirectionProvider from '../src/DirectionProvider';
-import { DIRECTIONS, CHANNEL } from '../src/constants';
 import mockBrcast from './mocks/brcast_mock';
 
 function getWrapper(props, context) {
@@ -201,7 +201,7 @@ describe('<DirectionProvider>', () => {
 
       it('sets initial state for inheritedDirection to the default direction', () => {
         const wrapper = getWrapper({ direction: null }, context);
-        expect(wrapper).to.have.state('inheritedDirection', DIRECTIONS.LTR);
+        expect(wrapper).to.have.state('inheritedDirection', defaultDirection);
       });
 
       it('does not call brcast subscribe when the component mounts', () => {


### PR DESCRIPTION
When rendering user-generated content, the direction could sometimes be
undefined. For example, a phone number or an empty string would not be strong
RTL/LTR text.

Before this PR, developers would have to check the direction and conditionally
render a DirectionProvider, which can be combersome.

With this PR `direction` can be undefined, in effect making DirectionProvider a
no-op. Decendent components that use `withDirection` would "skip" undefined
directions and use the context from the closest ancestor that has a defined
direction context (to be verified).

Question: I'm not sure if I need to change `withDirection.jsx` too. Will its `context` reference become stale because it's already subscribed? https://github.com/airbnb/react-with-direction/blob/7cde7e3370d0c4f774e101c42aa08e6a52a37219/src/withDirection.jsx#L41

to: @jasonkb @garrettberg @ljharb @majapw 