### PR TITLE
Updates DirectionProvider to use componentDidUpdate instead of UNSAFE_componentWillReceiveProps

### DIFF
--- a/src/DirectionProvider.jsx
+++ b/src/DirectionProvider.jsx
@@ -38,9 +38,9 @@ export default class DirectionProvider extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.direction !== nextProps.direction) {
-      this.broadcast.setState(nextProps.direction);
+  componentDidUpdate(prevProps) {
+    if (prevProps.direction !== this.props.direction) {
+      this.broadcast.setState(this.props.direction);
     }
   }
 

--- a/tests/DirectionProvider_test.jsx
+++ b/tests/DirectionProvider_test.jsx
@@ -1,6 +1,15 @@
+/**
+ * @jest-environment jsdom
+ */
+
+ // We must set the env to jsdom for this file to accommodate mounted components.
+ // The components must be mounted because there is currently no way to test
+ // code within componentDidUpdate lifecycle in shallow mounting.
+ // https://github.com/airbnb/enzyme/issues/1452
+
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import sinon from 'sinon-sandbox';
 
 import DirectionProvider from '../src/DirectionProvider';
@@ -40,7 +49,7 @@ describe('<DirectionProvider>', () => {
   it('broadcasts the direction when the direction prop changes', () => {
     const direction = DIRECTIONS.LTR;
     const nextDirection = DIRECTIONS.RTL;
-    const wrapper = shallow(
+    const wrapper = mount(
       <DirectionProvider direction={direction}>{children}</DirectionProvider>,
     );
     const broadcast = wrapper.instance().broadcast;
@@ -52,7 +61,7 @@ describe('<DirectionProvider>', () => {
   it('does not broadcast the direction when the direction prop stays the same', () => {
     const direction = DIRECTIONS.LTR;
     const nextDirection = DIRECTIONS.LTR;
-    const wrapper = shallow(
+    const wrapper = mount(
       <DirectionProvider direction={direction}>{children}</DirectionProvider>,
     );
     const broadcast = wrapper.instance().broadcast;

--- a/tests/_helpers.jsx
+++ b/tests/_helpers.jsx
@@ -5,6 +5,7 @@ import sinon from 'sinon-sandbox';
 import chaiEnzyme from 'chai-enzyme';
 
 import configure from 'enzyme-adapter-react-helper';
+import './shim';
 
 configure({ disableLifecycleMethods: true });
 

--- a/tests/shim.js
+++ b/tests/shim.js
@@ -1,0 +1,6 @@
+// This file is required to alleviate an RAF error that appears:
+// https://github.com/facebook/jest/issues/4545
+
+global.requestAnimationFrame = (callback) => {
+  setTimeout(callback, 0);
+};


### PR DESCRIPTION
This change migrates DirectionProvider to cease using `UNSAFE_componentWillMount` in favor of `componentDidUpdate` in accordance with

> If you need to perform a side effect (for example, data fetching or an animation) in response to a change in props, use componentDidUpdate lifecycle instead.
_from: https://reactjs.org/docs/react-component.html_

Unfortunately, since Enzyme lacks support for shallow mounting that fires `componentDidUpdate`, there is also a tangential change that includes `jsdom` as the environment that DirectionProvider's test is run in. And further, because this causes a warning to appear in the test regarding `requestAnimationFrame`, I used a method found in this thread to quell the warning: https://github.com/facebook/jest/issues/4545

One last thing to note: Some of the testing here was switched to `mount` in favor of `shallow`. This was to accommodate an ongoing issue with Enzyme being unable to trigger a call to cDU with `setProps` being called on a shallow wrapper. https://github.com/airbnb/enzyme/issues/1452