### PR TITLE
[DirectionProvider] Allow passing additional props to DirectionProvider

### DIFF
--- a/src/AutoDirectionProvider.jsx
+++ b/src/AutoDirectionProvider.jsx
@@ -6,12 +6,12 @@ import directionPropType from './proptypes/direction';
 import DirectionProvider from './DirectionProvider';
 import withDirection from './withDirection';
 
-const propTypes = forbidExtraProps({
+const propTypes = {
   children: PropTypes.node.isRequired,
   direction: directionPropType.isRequired,
   inline: PropTypes.bool,
   text: PropTypes.string.isRequired,
-});
+};
 
 const defaultProps = {
   inline: false,
@@ -22,12 +22,14 @@ function AutoDirectionProvider({
   direction,
   inline,
   text,
+  ...rest
 }) {
   const textDirection = getDirection(text);
   const dir = textDirection === 'neutral' ? direction : textDirection;
 
   return (
     <DirectionProvider
+      {...rest}
       direction={dir}
       inline={inline}
     >

--- a/src/DirectionProvider.jsx
+++ b/src/DirectionProvider.jsx
@@ -4,17 +4,16 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { forbidExtraProps } from 'airbnb-prop-types';
 import brcast from 'brcast';
 import brcastShape from './proptypes/brcast';
 import directionPropType from './proptypes/direction';
 import { DIRECTIONS, CHANNEL } from './constants';
 
-const propTypes = forbidExtraProps({
+const propTypes = {
   children: PropTypes.node.isRequired,
   direction: directionPropType.isRequired,
   inline: PropTypes.bool,
-});
+};
 
 const defaultProps = {
   inline: false,
@@ -45,10 +44,10 @@ export default class DirectionProvider extends React.Component {
   }
 
   render() {
-    const { children, direction, inline } = this.props;
+    const { children, direction, inline, ...rest } = this.props;
     const Tag = inline ? 'span' : 'div';
     return (
-      <Tag dir={direction}>
+      <Tag {...rest} dir={direction}>
         {React.Children.only(children)}
       </Tag>
     );

--- a/tests/AutoDirectionProvider_test.jsx
+++ b/tests/AutoDirectionProvider_test.jsx
@@ -18,6 +18,17 @@ describe('<AutoDirectionProvider>', () => {
     expect(wrapper).to.have.exactly(1).descendants(DirectionProvider);
   });
 
+  it('passes additional props to the DirectionProvider', () => {
+    const wrapper = shallow((
+      <AutoDirectionProvider text="a" data-foo="bar" style={{ background: 'red' }}>
+        <div />
+      </AutoDirectionProvider>
+    )).dive();
+
+    expect(wrapper.find(DirectionProvider).prop('data-foo')).to.equal('bar');
+    expect(wrapper.find(DirectionProvider).prop('style')).to.eql({ background: 'red' });
+  });
+
   describe('direction prop', () => {
     it('is LTR correct for LTR strings', () => {
       const wrapper = shallow((

--- a/tests/DirectionProvider_test.jsx
+++ b/tests/DirectionProvider_test.jsx
@@ -60,4 +60,18 @@ describe('<DirectionProvider>', () => {
     wrapper.setProps({ direction: nextDirection });
     expect(broadcastSpy).to.have.callCount(0);
   });
+
+  it('renders a wrapping div and allows passing additional props', () => {
+    const direction = DIRECTIONS.RTL;
+    const wrapper = shallow(
+      <DirectionProvider
+        direction={direction}
+        data-foo="bar"
+        style={{ background: 'red' }}
+      >{children}</DirectionProvider>,
+    );
+
+    expect(wrapper.prop('data-foo')).to.equal('bar');
+    expect(wrapper.prop('style')).to.eql({ background: 'red' });
+  });
 });


### PR DESCRIPTION
This PR adds the ability to pass additional props (`...rest`) to the Tag rendered by the `DirectionProvider`. In addition, it passes additional props from the `AutoDirectionProvider` to the `DirectionProvider`.

The goal of this PR is to reduce the number of nodes rendered on any given page. If we can re-use the DOM node created by the Direction Provider, we can reduce nesting by 1.