### PR TITLE
Add 'direction' option (prop) to 'withDirection' HOC, This to allow the overwrite of the direction when required

### DIFF
--- a/src/withDirection.jsx
+++ b/src/withDirection.jsx
@@ -23,16 +23,19 @@ const defaultDirection = DIRECTIONS.LTR;
 
 // export for convenience, in order for components to spread these onto their propTypes
 export const withDirectionPropTypes = {
-  direction: directionPropType.isRequired,
+  direction: directionPropType,
 };
 
 export default function withDirection(WrappedComponent) {
   class WithDirection extends React.Component {
     constructor(props, context) {
       super(props, context);
-      this.state = {
-        direction: context[CHANNEL] ? context[CHANNEL].getState() : defaultDirection,
-      };
+      let direction = context[CHANNEL] ? context[CHANNEL].getState() : defaultDirection;
+      // console.log(props.direction);
+      if (props.direction) {
+        direction = props.direction;
+      }
+      this.state = { direction };
     }
 
     componentDidMount() {
@@ -68,8 +71,7 @@ export default function withDirection(WrappedComponent) {
   WithDirection.contextTypes = contextTypes;
   WithDirection.displayName = `withDirection(${wrappedComponentName})`;
   if (WrappedComponent.propTypes) {
-    WithDirection.propTypes = deepmerge({}, WrappedComponent.propTypes);
-    delete WithDirection.propTypes.direction;
+    WithDirection.propTypes = deepmerge(WrappedComponent.propTypes, withDirectionPropTypes);
   }
   if (WrappedComponent.defaultProps) {
     WithDirection.defaultProps = deepmerge({}, WrappedComponent.defaultProps);

--- a/tests/AutoDirectionProvider_test.jsx
+++ b/tests/AutoDirectionProvider_test.jsx
@@ -56,6 +56,38 @@ describe('<AutoDirectionProvider>', () => {
 
       expect(wrapper.find(DirectionProvider)).to.have.prop('direction', DIRECTIONS.RTL);
     });
+
+    it('is RTL correct for overwriten direction prop for neutral strings', () => {
+      const wrapper = shallow(
+        <AutoDirectionProvider text="(555) 555 5555" direction={DIRECTIONS.RTL}>
+          <div />
+        </AutoDirectionProvider>,
+      ).dive();
+      expect(wrapper.find(DirectionProvider)).to.have.prop('direction', DIRECTIONS.RTL);
+    });
+
+    it('is LTR correct for overwriten direction prop for neutral strings', () => {
+      const wrapper = shallow(
+        <AutoDirectionProvider text="(555) 555 5555" direction={DIRECTIONS.LTR}>
+          <div />
+        </AutoDirectionProvider>,
+      ).dive();
+      expect(wrapper.find(DirectionProvider)).to.have.prop('direction', DIRECTIONS.LTR);
+    });
+
+    it('is RTL correct for overwriten context direction when no text value is provided', () => {
+      const wrapper = shallow(
+        <DirectionProvider direction={DIRECTIONS.LTR}>
+          <AutoDirectionProvider text="" direction={DIRECTIONS.RTL}>
+            <div />
+          </AutoDirectionProvider>
+        </DirectionProvider>,
+      )
+        .find(AutoDirectionProvider)
+        .shallow()
+        .dive();
+      expect(wrapper.find(DirectionProvider)).to.have.prop('direction', DIRECTIONS.RTL);
+    });
   });
 
   it('renders its children', () => {

--- a/tests/withDirection_test.jsx
+++ b/tests/withDirection_test.jsx
@@ -49,6 +49,23 @@ describe('withDirection()', () => {
     );
   });
 
+  describe('overwrite direction', () => {
+    it('uses the provided direction to overwrite the default', () => {
+      const Wrapped = getWrappedComponent(DIRECTIONS.RTL);
+      render(<Wrapped direction={DIRECTIONS.RTL} />);
+    });
+    it('uses the provided direction to overwrite the context', () => {
+      const Wrapped = getWrappedComponent(DIRECTIONS.LTR);
+      render(
+        <DirectionProvider direction={DIRECTIONS.RTL}>
+          <div>
+            <Wrapped direction={DIRECTIONS.LTR} />
+          </div>
+        </DirectionProvider>,
+      );
+    });
+  });
+
   describe('lifecycle methods', () => {
     let brcast;
     beforeEach(() => {


### PR DESCRIPTION
Add 'direction' option (prop) to 'withDirection' HOC, This to allow the overwrite of the direction when required (for phone numbers for example that are always LTR), updated packages