### PR TITLE
mark deprecated lifecycle method with `UNSAFE`

### DIFF
--- a/src/DirectionProvider.jsx
+++ b/src/DirectionProvider.jsx
@@ -38,7 +38,7 @@ export default class DirectionProvider extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.direction !== nextProps.direction) {
       this.broadcast.setState(nextProps.direction);
     }


### PR DESCRIPTION
The noise this is causing in react 16.9 is a bit much, until a proper solution is resolved in https://github.com/airbnb/react-with-direction/pull/14 let's just mark it unsafe.