### PR TITLE
[Deps] Update hoist-non-react-statics to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "brcast": "^2.0.2",
     "deepmerge": "^1.5.2",
     "direction": "^1.0.2",
-    "hoist-non-react-statics": "^2.5.5",
+    "hoist-non-react-statics": "^3.3.0",
     "object.assign": "^4.1.0",
     "object.values": "^1.0.4",
     "prop-types": "^15.6.2"


### PR DESCRIPTION
Allows use of React 16.3+ features like `contextType`. The major
version bump was due to dropping support for React < 0.14, so
this is not a major change.

https://github.com/mridgway/hoist-non-react-statics/blob/master/CHANGELOG.md#300-july-27-2018

Doing this so that we don't copy newer react statics like 
`contextType` onto the withDirection HOC.

@ljharb @TaeKimJr @indiesquidge @ahuth @joeuy @lencioni @majapw 